### PR TITLE
Updated link for main Vault repo as it was not rendering properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ instructions are only useful if you want to develop against the plugin.**
 ### Documentation
 
 The documentation for the plugin lives in the [main Vault
-repository](/hashicorp/vault) in the `website/` folder. Please make any
+repository](//github.com/hashicorp/vault) in the `website/` folder. Please make any
 documentation updates as separate Pull Requests against that repo.
 
 ### Tests


### PR DESCRIPTION
Sorry for submitting this twice, had to update my git config. Anyway, updated the link to the vault repo to a protocol relative url as the original one was not linking correctly to the vault repo.