### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Next
 
+CHANGES:
+
+* Changes user-agent header value to use correct Vault version information and include
+  the plugin type and name in the comment section.
+
 IMPROVEMENTS:
 
 * Updates dependency `google.golang.org/api@v0.83.0`

--- a/backend.go
+++ b/backend.go
@@ -2,6 +2,7 @@ package gcpkms
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -98,8 +99,7 @@ func Backend() *backend {
 func (b *backend) initialize(ctx context.Context, _ *logical.InitializationRequest) error {
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
-			"error", err)
+		return fmt.Errorf("failed to read plugin environment: %w", err)
 	}
 	b.pluginEnv = pluginEnv
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
-	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/logical"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -70,7 +69,6 @@ func testKMSClient(tb testing.TB) *kmsapi.KeyManagementClient {
 	ctx := context.Background()
 	kmsClient, err := kmsapi.NewKeyManagementClient(ctx,
 		option.WithScopes(defaultScope),
-		option.WithUserAgent(useragent.String()),
 	)
 	if err != nil {
 		tb.Fatalf("failed to create kms client: %s", err)


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. Using `useragent.PluginString` will allow plugins running external to Vault to use correct Vault version information in construction of user-agent request headers regardless of the compiled SDK version.

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault/pull/14229
