### PR TITLE
v0.15.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 ## Unreleased
 
+## v0.15.1
+
+IMPROVEMENTS:
+
+* Updated dependencies:
+   * `cloud.google.com/go/kms` v1.6.0 -> v1.15.1
+   * `github.com/gammazero/workerpool` v0.0.0-20190406235159-88d534f22b56 -> v1.1.3
+   * `github.com/golang/protobuf` v1.5.2 -> v1.5.3
+   * `github.com/hashicorp/go-hclog` v0.16.2 -> v1.5.0
+   * `github.com/hashicorp/vault/api` v1.9.0 -> v1.9.2
+   * `github.com/hashicorp/vault/sdk` v0.9.0 -> v0.9.2
+   * `golang.org/x/oauth2` v0.4.0 -> v0.11.0
+   * `google.golang.org/api` v0.103.0 -> v0.138.0
+   * `google.golang.org/genproto` v0.0.0-20230110181048-76db0878b65f -> v0.0.0-20230822172742-b8732ec3820d
+   * `google.golang.org/grpc` v1.47.0 -> v1.57.0
+
 ## v0.15.0
 
-### IMPROVEMENTS:
+IMPROVEMENTS:
 
 * enable plugin multiplexing [GH-26](https://github.com/hashicorp/vault-plugin-secrets-gcpkms/pull/26)
 * update dependencies


### PR DESCRIPTION
## v0.15.1

### Improvements

* Updated dependencies:
   * `cloud.google.com/go/kms` v1.6.0 -> v1.15.1
   * `github.com/gammazero/workerpool` v0.0.0-20190406235159-88d534f22b56 -> v1.1.3
   * `github.com/golang/protobuf` v1.5.2 -> v1.5.3
   * `github.com/hashicorp/go-hclog` v0.16.2 -> v1.5.0
   * `github.com/hashicorp/vault/api` v1.9.0 -> v1.9.2
   * `github.com/hashicorp/vault/sdk` v0.9.0 -> v0.9.2
   * `golang.org/x/oauth2` v0.4.0 -> v0.11.0
   * `google.golang.org/api` v0.103.0 -> v0.138.0
   * `google.golang.org/genproto` v0.0.0-20230110181048-76db0878b65f -> v0.0.0-20230822172742-b8732ec3820d
   * `google.golang.org/grpc` v1.47.0 -> v1.57.0