### PR TITLE
Counting of successful requests for billing

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -60,8 +60,7 @@ type backend struct {
 	ctxCancel context.CancelFunc
 	ctxLock   sync.Mutex
 
-	// billingDataCounts tracks the number of data protection operations for billing purposes.
-	// This counter is also used in tests to verify billing data tracking.
+	// For testing purposes only. Used to track the number of billing data requests.
 	billingDataCounts atomic.Uint64
 }
 

--- a/backend.go
+++ b/backend.go
@@ -128,12 +128,9 @@ func (b *backend) incrementBillingDataCount(ctx context.Context, count uint64) e
 	b.billingDataCounts.Add(count)
 
 	// Write billing data to the consumption billing manager
-	if b.ConsumptionBillingManager != nil {
-		return b.ConsumptionBillingManager.WriteBillingData(ctx, "gcpkms", map[string]interface{}{
-			"count": count,
-		})
-	}
-	return nil
+	return b.ConsumptionBillingManager.WriteBillingData(ctx, "gcpkms", map[string]interface{}{
+		"count": count,
+	})
 }
 
 // clean cancels the shared contexts. This is called just before unmounting

--- a/backend.go
+++ b/backend.go
@@ -128,9 +128,12 @@ func (b *backend) incrementBillingDataCount(ctx context.Context, count uint64) e
 	b.billingDataCounts.Add(count)
 
 	// Write billing data to the consumption billing manager
-	return b.ConsumptionBillingManager.WriteBillingData(ctx, "gcpkms", map[string]interface{}{
-		"count": count,
-	})
+	if b.ConsumptionBillingManager != nil {
+		return b.ConsumptionBillingManager.WriteBillingData(ctx, "gcpkms", map[string]interface{}{
+			"count": count,
+		})
+	}
+	return nil
 }
 
 // clean cancels the shared contexts. This is called just before unmounting

--- a/backend.go
+++ b/backend.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -58,6 +59,10 @@ type backend struct {
 	ctx       context.Context
 	ctxCancel context.CancelFunc
 	ctxLock   sync.Mutex
+
+	// billingDataCounts tracks the number of data protection operations for billing purposes.
+	// This counter is also used in tests to verify billing data tracking.
+	billingDataCounts atomic.Uint64
 }
 
 // Factory returns a configured instance of the backend.
@@ -117,6 +122,16 @@ func (b *backend) initialize(ctx context.Context, _ *logical.InitializationReque
 	b.pluginEnv = pluginEnv
 
 	return nil
+}
+
+func (b *backend) incrementBillingDataCount(ctx context.Context, count uint64) error {
+	// Increment the billing data count for testing
+	b.billingDataCounts.Add(count)
+
+	// Write billing data to the consumption billing manager
+	return b.ConsumptionBillingManager.WriteBillingData(ctx, "gcpkms", map[string]interface{}{
+		"count": count,
+	})
 }
 
 // clean cancels the shared contexts. This is called just before unmounting

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jeffchao/backoff v0.0.0-20140404060208-9d7fd7aa17f2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/satori/go.uuid v1.2.0
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/api v0.272.0
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7
@@ -105,7 +106,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect

--- a/path_decrypt.go
+++ b/path_decrypt.go
@@ -169,7 +169,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		return nil, logical.ErrUnsupportedOperation
 	}
 
-    // successful request, increment billing count. 
+	// successful request, increment billing count
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS decryption billing data", "error", err)
 	}

--- a/path_decrypt.go
+++ b/path_decrypt.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -166,6 +167,10 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		plaintext = string(resp.Plaintext)
 	case kmspb.CryptoKey_ASYMMETRIC_SIGN:
 		return nil, logical.ErrUnsupportedOperation
+	}
+
+	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
+		b.Logger().Error("failed to write GCP KMS decryption billing data", "error", err)
 	}
 
 	return &logical.Response{

--- a/path_decrypt.go
+++ b/path_decrypt.go
@@ -169,6 +169,7 @@ func (b *backend) pathDecryptWrite(ctx context.Context, req *logical.Request, d 
 		return nil, logical.ErrUnsupportedOperation
 	}
 
+    // successful request, increment billing count. 
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS decryption billing data", "error", err)
 	}

--- a/path_decrypt_test.go
+++ b/path_decrypt_test.go
@@ -15,12 +15,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
 func TestPathDecrypt_Write(t *testing.T) {
-
 	t.Run("field_validation", func(t *testing.T) {
 		testFieldValidation(t, logical.UpdateOperation, "decrypt/my-key")
 	})
@@ -99,6 +99,8 @@ func TestPathDecrypt_Write(t *testing.T) {
 				if v := resp.Data["plaintext"]; v != exp {
 					t.Errorf("expected %q to be %q", v, exp)
 				}
+
+				require.Equal(t, uint64(1), b.billingDataCounts.Load())
 			})
 		}
 	})
@@ -164,6 +166,8 @@ func TestPathDecrypt_Write(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+
+				require.Equal(t, uint64(1), b.billingDataCounts.Load())
 
 				if v, exp := resp.Data["plaintext"], tc.exp; v != exp {
 					t.Errorf("expected %q to be %q", v, exp)

--- a/path_decrypt_test.go
+++ b/path_decrypt_test.go
@@ -100,6 +100,7 @@ func TestPathDecrypt_Write(t *testing.T) {
 					t.Errorf("expected %q to be %q", v, exp)
 				}
 
+				// Verify billing data count incremented
 				require.Equal(t, uint64(1), b.billingDataCounts.Load())
 			})
 		}

--- a/path_encrypt.go
+++ b/path_encrypt.go
@@ -120,6 +120,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		return nil, errwrap.Wrapf("failed to encrypt plaintext: {{err}}", err)
 	}
 
+   // successful request, increment billing count. 
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS encryption billing data", "error", err)
 	}

--- a/path_encrypt.go
+++ b/path_encrypt.go
@@ -120,7 +120,7 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		return nil, errwrap.Wrapf("failed to encrypt plaintext: {{err}}", err)
 	}
 
-   // successful request, increment billing count. 
+	// successful request, increment billing count
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS encryption billing data", "error", err)
 	}

--- a/path_encrypt.go
+++ b/path_encrypt.go
@@ -120,6 +120,10 @@ func (b *backend) pathEncryptWrite(ctx context.Context, req *logical.Request, d 
 		return nil, errwrap.Wrapf("failed to encrypt plaintext: {{err}}", err)
 	}
 
+	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
+		b.Logger().Error("failed to write GCP KMS encryption billing data", "error", err)
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"key_version": path.Base(resp.Name),

--- a/path_encrypt_test.go
+++ b/path_encrypt_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
@@ -61,6 +62,7 @@ func TestPathEncrypt_Write(t *testing.T) {
 	}
 
 	t.Run("group", func(t *testing.T) {
+		expectedBillingCount := uint64(0)
 		for _, tc := range cases {
 			tc := tc
 
@@ -106,6 +108,10 @@ func TestPathEncrypt_Write(t *testing.T) {
 				if v, exp := string(decryptResp.Plaintext), tc.pt; v != exp {
 					t.Errorf("expected %q to be %q", v, exp)
 				}
+
+				// Verify billing data count incremented
+				expectedBillingCount++
+				require.Equal(t, expectedBillingCount, b.billingDataCounts.Load())
 			})
 		}
 	})

--- a/path_keys_verify.go
+++ b/path_keys_verify.go
@@ -182,7 +182,7 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		return nil, fmt.Errorf("unknown key signing algorithm: %s", pk.Algorithm)
 	}
 
-	// Track billing data for successful verify operation
+	// successful request, increment billing count
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS verification billing data", "error", err)
 	}

--- a/path_keys_verify.go
+++ b/path_keys_verify.go
@@ -182,6 +182,11 @@ func (b *backend) pathVerifyWrite(ctx context.Context, req *logical.Request, d *
 		return nil, fmt.Errorf("unknown key signing algorithm: %s", pk.Algorithm)
 	}
 
+	// Track billing data for successful verify operation
+	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
+		b.Logger().Error("failed to write GCP KMS verification billing data", "error", err)
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"valid": validSig,

--- a/path_keys_verify_test.go
+++ b/path_keys_verify_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
@@ -119,6 +120,9 @@ func TestPathVerify_Write(t *testing.T) {
 				if b, ok := valid.(bool); !ok || !b {
 					t.Errorf("expected valid %t to be %t", b, true)
 				}
+
+				// Verify billing data count incremented
+				require.Equal(t, uint64(1), b.billingDataCounts.Load())
 			})
 		}
 	})

--- a/path_reencrypt.go
+++ b/path_reencrypt.go
@@ -133,6 +133,7 @@ func (b *backend) pathReencryptWrite(ctx context.Context, req *logical.Request, 
 		return nil, errwrap.Wrapf("failed to encrypt new plaintext: {{err}}", err)
 	}
 
+	// successful request, increment billing count
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS reencryption billing data", "error", err)
 	}

--- a/path_reencrypt.go
+++ b/path_reencrypt.go
@@ -133,6 +133,10 @@ func (b *backend) pathReencryptWrite(ctx context.Context, req *logical.Request, 
 		return nil, errwrap.Wrapf("failed to encrypt new plaintext: {{err}}", err)
 	}
 
+	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
+		b.Logger().Error("failed to write GCP KMS reencryption billing data", "error", err)
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"key_version": path.Base(encResp.Name),

--- a/path_reencrypt_test.go
+++ b/path_reencrypt_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathReencrypt_Write(t *testing.T) {
@@ -145,6 +146,9 @@ func TestPathReencrypt_Write(t *testing.T) {
 			if ciphertextV1 == ciphertextV2 {
 				t.Errorf("not reencrypted")
 			}
+
+			// Verify billing data count incremented (1 encrypt + 1 reencrypt)
+			require.Equal(t, uint64(2), b.billingDataCounts.Load())
 		})
 
 		t.Run("less_min_version", func(t *testing.T) {

--- a/path_sign.go
+++ b/path_sign.go
@@ -152,7 +152,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		return nil, errwrap.Wrapf("failed to sign digest: {{err}}", err)
 	}
 
-	// Track billing data for successful sign operation
+	// successful request, increment billing count
 	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
 		b.Logger().Error("failed to write GCP KMS signing billing data", "error", err)
 	}

--- a/path_sign.go
+++ b/path_sign.go
@@ -152,6 +152,11 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		return nil, errwrap.Wrapf("failed to sign digest: {{err}}", err)
 	}
 
+	// Track billing data for successful sign operation
+	if err := b.incrementBillingDataCount(ctx, 1); err != nil {
+		b.Logger().Error("failed to write GCP KMS signing billing data", "error", err)
+	}
+
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"signature": base64.StdEncoding.EncodeToString(resp.Signature),

--- a/path_sign_test.go
+++ b/path_sign_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/stretchr/testify/require"
 
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
@@ -157,6 +158,9 @@ func TestPathSign_Write(t *testing.T) {
 				default:
 					t.Fatalf("unknown algorithm: %s", pk.Algorithm)
 				}
+
+				// Verify billing data count incremented
+				require.Equal(t, uint64(1), b.billingDataCounts.Load())
 			})
 		}
 	})


### PR DESCRIPTION
# Overview
This PR adds tracking for successful requests count for consumption billing purposes.
Specifically, the following paths are tracked:
```
/gcpkms/decrypt/:key
/gcpkms/encrypt/:key
/gcpkms/reencrypt/:key
/gcpkms/sign/:key
/gcpkms/verify/:key
```
This change should not affect user experience.

Testing:
```
10:33:02 amiraslamov ~/Documents/GitHub/external-plugins/vault-plugin-secrets-gcpkms (aslamovamir-vault-43310-external-gcp-kms-counting)$ make test
ok      github.com/hashicorp/vault-plugin-secrets-gcpkms        76.477s
?       github.com/hashicorp/vault-plugin-secrets-gcpkms/cmd/vault-plugin-secrets-gcpkms        [no test files]
?       github.com/hashicorp/vault-plugin-secrets-gcpkms/test/cleanup   [no test files]
?       github.com/hashicorp/vault-plugin-secrets-gcpkms/version        [no test files]
?       github.com/hashicorp/vault-plugin-secrets-gcpkms/version/cmd    [no test files]
```

# Related Issues/Pull Requests
https://hashicorp.atlassian.net/browse/VAULT-43310

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
