### PR TITLE
Added missing metadata for OpenAPI endpoints

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -47,28 +47,52 @@ requests https://www.googleapis.com/auth/cloudkms.
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathConfigWrite),
+				Summary:  "Configure the GCP KMS secrets engine.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathConfigWrite),
+				Summary:  "Configure the GCP KMS secrets engine.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathConfigRead),
+				Summary:  "Return the GCP KMS secrets engine configuration.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "read",
 					OperationSuffix: "configuration",
 				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"scopes": {
+								Type:        framework.TypeSlice,
+								Description: "List of OAuth2 scopes requested when authenticating.",
+							},
+						},
+					}},
+				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathConfigDelete),
+				Summary:  "Delete the GCP KMS secrets engine configuration.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "delete",
 					OperationSuffix: "configuration",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},

--- a/path_config.go
+++ b/path_config.go
@@ -77,7 +77,7 @@ requests https://www.googleapis.com/auth/cloudkms.
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"scopes": {
-								Type:        framework.TypeSlice,
+								Type:        framework.TypeCommaStringSlice,
 								Description: "List of OAuth2 scopes requested when authenticating.",
 							},
 						},

--- a/path_decrypt.go
+++ b/path_decrypt.go
@@ -68,8 +68,22 @@ correct version automatically.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathDecryptWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathDecryptWrite),
+				Summary:  "Decrypt a ciphertext value using a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"plaintext": {
+								Type:        framework.TypeString,
+								Description: "Decrypted plaintext value.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_encrypt.go
+++ b/path_encrypt.go
@@ -75,7 +75,7 @@ limitations by key types.
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"key_version": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt,
 								Description: "Key version used for encryption.",
 							},
 							"ciphertext": {

--- a/path_encrypt.go
+++ b/path_encrypt.go
@@ -66,8 +66,26 @@ limitations by key types.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathEncryptWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathEncryptWrite),
+				Summary:  "Encrypt a plaintext value using a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"key_version": {
+								Type:        framework.TypeString,
+								Description: "Key version used for encryption.",
+							},
+							"ciphertext": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded encrypted ciphertext.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_keys.go
+++ b/path_keys.go
@@ -44,17 +44,6 @@ func (b *backend) pathKeys() *framework.Path {
 			logical.ListOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysList),
 				Summary:  "List all named keys.",
-				Responses: map[int][]framework.Response{
-					200: {{
-						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"keys": {
-								Type:        framework.TypeSlice,
-								Description: "List of named keys.",
-							},
-						},
-					}},
-				},
 			},
 		},
 	}

--- a/path_keys.go
+++ b/path_keys.go
@@ -40,8 +40,22 @@ func (b *backend) pathKeys() *framework.Path {
 		HelpSynopsis:    "List named keys",
 		HelpDescription: "List the named keys available for use.",
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: withFieldValidator(b.pathKeysList),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysList),
+				Summary:  "List all named keys.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "List of named keys.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }
@@ -177,11 +191,75 @@ labels, specify this argument multiple times (e.g. labels="a=b" labels="c=d").
 
 		ExistenceCheck: b.pathKeysExistenceCheck,
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   withFieldValidator(b.pathKeysRead),
-			logical.CreateOperation: withFieldValidator(b.pathKeysWrite),
-			logical.UpdateOperation: withFieldValidator(b.pathKeysWrite),
-			logical.DeleteOperation: withFieldValidator(b.pathKeysDelete),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysRead),
+				Summary:  "Return information about a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"id": {
+								Type:        framework.TypeString,
+								Description: "Full Google Cloud KMS resource ID of the key.",
+							},
+							"purpose": {
+								Type:        framework.TypeString,
+								Description: "Purpose of the crypto key.",
+							},
+							"labels": {
+								Type:        framework.TypeMap,
+								Description: "Labels applied to the crypto key.",
+							},
+							"next_rotation_time_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix epoch timestamp of the next scheduled rotation.",
+							},
+							"rotation_schedule_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Rotation period in seconds.",
+							},
+							"primary_version": {
+								Type:        framework.TypeString,
+								Description: "Primary crypto key version.",
+							},
+							"state": {
+								Type:        framework.TypeString,
+								Description: "State of the primary crypto key version.",
+							},
+							"protection_level": {
+								Type:        framework.TypeString,
+								Description: "Protection level of the key.",
+							},
+							"algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm of the key version template.",
+							},
+						},
+					}},
+				},
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysWrite),
+				Summary:  "Create or update a named key.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysWrite),
+				Summary:  "Create or update a named key.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
+			},
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysDelete),
+				Summary:  "Delete a named key.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
+			},
 		},
 	}
 }

--- a/path_keys.go
+++ b/path_keys.go
@@ -212,11 +212,11 @@ labels, specify this argument multiple times (e.g. labels="a=b" labels="c=d").
 								Description: "Labels applied to the crypto key.",
 							},
 							"next_rotation_time_seconds": {
-								Type:        framework.TypeInt,
+								Type:        framework.TypeInt64,
 								Description: "Unix epoch timestamp of the next scheduled rotation.",
 							},
 							"rotation_schedule_seconds": {
-								Type:        framework.TypeInt,
+								Type:        framework.TypeInt64,
 								Description: "Rotation period in seconds.",
 							},
 							"primary_version": {

--- a/path_keys_config.go
+++ b/path_keys_config.go
@@ -61,23 +61,55 @@ negative value, there is no maximum key version.
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysConfigRead),
+				Summary:  "Return the Vault configuration for a named key.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "read",
 					OperationSuffix: "key-configuration",
 				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"name": {
+								Type:        framework.TypeString,
+								Description: "Name of the key in Vault.",
+							},
+							"crypto_key": {
+								Type:        framework.TypeString,
+								Description: "Full Google Cloud KMS resource ID of the crypto key.",
+							},
+							"min_version": {
+								Type:        framework.TypeInt,
+								Description: "Minimum allowed crypto key version.",
+							},
+							"max_version": {
+								Type:        framework.TypeInt,
+								Description: "Maximum allowed crypto key version.",
+							},
+						},
+					}},
+				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysConfigWrite),
+				Summary:  "Configure a named key in Vault.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "configure",
 					OperationSuffix: "key",
 				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysConfigWrite),
+				Summary:  "Configure a named key in Vault.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "configure",
 					OperationSuffix: "key",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},

--- a/path_keys_deregister.go
+++ b/path_keys_deregister.go
@@ -39,14 +39,22 @@ it will be left untouched.
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysDeregisterWrite),
+				Summary:  "Deregister a key from Vault.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "key",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysDeregisterWrite),
+				Summary:  "Deregister a key from Vault.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "key2",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},

--- a/path_keys_register.go
+++ b/path_keys_register.go
@@ -62,8 +62,14 @@ not exist at creation time.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathKeysRegisterWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysRegisterWrite),
+				Summary:  "Register an existing crypto key in Google Cloud KMS.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
+			},
 		},
 	}
 }

--- a/path_keys_rotate.go
+++ b/path_keys_rotate.go
@@ -54,8 +54,22 @@ point to a valid Google Cloud KMS crypto key.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathKeysRotateWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathKeysRotateWrite),
+				Summary:  "Rotate a crypto key to a new primary version.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"key_version": {
+								Type:        framework.TypeString,
+								Description: "New primary crypto key version.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_keys_rotate.go
+++ b/path_keys_rotate.go
@@ -63,7 +63,7 @@ point to a valid Google Cloud KMS crypto key.
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"key_version": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt,
 								Description: "New primary crypto key version.",
 							},
 						},

--- a/path_keys_trim.go
+++ b/path_keys_trim.go
@@ -64,20 +64,32 @@ Name of the key in Vault.
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysTrimWrite),
+				Summary:  "Trim old crypto key versions from Google Cloud KMS.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "key-versions",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysTrimWrite),
+				Summary:  "Trim old crypto key versions from Google Cloud KMS.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "key-versions",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: withFieldValidator(b.pathKeysTrimWrite),
+				Summary:  "Trim old crypto key versions from Google Cloud KMS.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "key-versions2",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 			},
 		},

--- a/path_keys_verify.go
+++ b/path_keys_verify.go
@@ -71,8 +71,22 @@ Base64-encoded signature to use for verification. This field is required.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathVerifyWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathVerifyWrite),
+				Summary:  "Verify a signature using a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"valid": {
+								Type:        framework.TypeBool,
+								Description: "Whether the signature is valid.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_pubkey.go
+++ b/path_pubkey.go
@@ -48,8 +48,26 @@ This field is required.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation: withFieldValidator(b.pathPubkeyRead),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathPubkeyRead),
+				Summary:  "Retrieve the public key associated with a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"pem": {
+								Type:        framework.TypeString,
+								Description: "PEM-encoded public key.",
+							},
+							"algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm of the public key.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_reencrypt.go
+++ b/path_reencrypt.go
@@ -74,7 +74,7 @@ unspecified, this defaults to the latest active crypto key version.
 						Description: "OK",
 						Fields: map[string]*framework.FieldSchema{
 							"key_version": {
-								Type:        framework.TypeString,
+								Type:        framework.TypeInt,
 								Description: "Key version used for re-encryption.",
 							},
 							"ciphertext": {

--- a/path_reencrypt.go
+++ b/path_reencrypt.go
@@ -65,8 +65,26 @@ unspecified, this defaults to the latest active crypto key version.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathReencryptWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathReencryptWrite),
+				Summary:  "Re-encrypt existing ciphertext data to a new version.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"key_version": {
+								Type:        framework.TypeString,
+								Description: "Key version used for re-encryption.",
+							},
+							"ciphertext": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded re-encrypted ciphertext.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }

--- a/path_sign.go
+++ b/path_sign.go
@@ -57,8 +57,22 @@ required.
 			},
 		},
 
-		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.UpdateOperation: withFieldValidator(b.pathSignWrite),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: withFieldValidator(b.pathSignWrite),
+				Summary:  "Sign a message or digest using a named key.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"signature": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded signature.",
+							},
+						},
+					}},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
# Overview
A high level description of the contribution, including:
Who the change affects or is for (stakeholders)?
The change affects mainly people who use the Vault's UI. With the added fields, they can better understand the endpoints in the secrets gcpkms plugin.

What is the change? 
I added the missing operation summary, proper typed response schema, and fixed the path descriptions for the secrets gcpkms plugin.


Why is the change needed?
The change is needed because many of the plugins in vault were missing path descriptions, operation summaries, and typed response schemas. Many of the response schemas had a bare 200 Description OK response, which is not sufficient.


How does this change affect the user experience (if at all)?
When someone uses the Vault UI, they are able to understand the vault plugins better because they have a detailed description of what the endpoint does and meaningful response schema. With the response schema, they can understand what the endpoint returns.



# Design of Change
How was this change implemented?
I developed an AI skill that automatically adds the HelpSynopsis, Summary, and Response Fields. The Help Synopsis field helps with the path descriptions, and the Help Description and path name are used to come up with the Help Synopsis field. The path name, Operation Prefix, and Operation Suffix are used to come up with the operation summary. For the response schema, the AI skill is able to detect what data types are being added to the response data map, and the skill generates a response schema with those data types. For methods that return a nil, nil, a 204 response code is added.